### PR TITLE
Enabled stencil buffer in PP settings

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -309,3 +309,7 @@ SyncSceneSmoothingFactor=0.000000
 InitialAverageFrameRate=0.016667
 PhysXTreeRebuildRate=10
 DefaultBroadphaseSettings=(bUseMBPOnClient=True,bUseMBPOnServer=True,MBPBounds=(Min=(X=-102400.000000,Y=-102400.000000,Z=-51200.000000),Max=(X=102400.000000,Y=102400.000000,Z=51200.000000),IsValid=0),MBPNumSubdivs=8)
+
+[/Script/Engine.RendererSettings]
+r.CustomDepth=3
+


### PR DESCRIPTION
- Better parity with game, which according to my testing does use the stencil buffer